### PR TITLE
Make build options align with normal usage and add installing

### DIFF
--- a/buildcontrol.py
+++ b/buildcontrol.py
@@ -2,6 +2,7 @@
 # Flare Build Control
 #
 
+import os
 
 def recurse(ctx, directories):
     for d in directories:
@@ -14,7 +15,7 @@ def options(opt):
     copts.add_option('--tools-path',
                      default=None,
                      dest='flare_tools_path',
-                     help='Path to tools')
+                     help='Path to tools (installed prefix)')
     copts.add_option('--compiler-prefix',
                      default=None,
                      dest='flare_compiler_prefix',
@@ -48,25 +49,28 @@ def configure(conf):
     if conf.options.flare_tools_path == None:
         tool_path_list = os.environ['PATH']
     else:
-        tool_path_list = conf.options.flare_tools_path
+        if os.path.exists(os.path.join(conf.options.flare_tools_path, 'bin')):
+            tool_path_list = os.path.join(conf.options.flare_tools_path, 'bin')
+        else:
+            tool_path_list = conf.options.flare_tools_path
 
-    conf.find_program(tools_prefix + '-gcc',
+    conf.find_program(tools_prefix + 'gcc',
                       path_list=tool_path_list,
                       var="CC")
-    conf.find_program(tools_prefix + '-g++',
+    conf.find_program(tools_prefix + 'g++',
                       path_list=tool_path_list,
                       var="CXX")
-    conf.find_program(tools_prefix + '-gcc',
+    conf.find_program(tools_prefix + 'gcc',
                       path_list=tool_path_list,
                       var="LINK_CC")
-    conf.find_program(tools_prefix + '-g++',
+    conf.find_program(tools_prefix + 'g++',
                       path_list=tool_path_list,
                       var="LINK_CXX")
-    conf.find_program(tools_prefix + '-gcc',
+    conf.find_program(tools_prefix + 'gcc',
                       path_list=tool_path_list,
                       var="AS")
-    conf.find_program(tools_prefix + '-ld', path_list=tool_path_list, var="LD")
-    conf.find_program(tools_prefix + '-ar', path_list=tool_path_list, var="AR")
+    conf.find_program(tools_prefix + 'ld', path_list=tool_path_list, var="LD")
+    conf.find_program(tools_prefix + 'ar', path_list=tool_path_list, var="AR")
 
     conf.load('gcc')
     conf.load('g++')

--- a/wscript
+++ b/wscript
@@ -71,4 +71,5 @@ def build(bld):
                 includes=builditems.get_includes(bld, includes),
                 defines=builditems.get_defines(bld, defines),
                 source=builditems.get_items(bld, sources),
-                use=['flare', 'flare_drivers'])
+                use=['flare', 'flare_drivers'],
+                install_path='${PREFIX}/share/flare/${FLARE_BOARD}')


### PR DESCRIPTION
The option `--compiler-prefix` is normally called `--exec-prefix` and has the trailing `-`. This patch moves Flare closer to this by requiring the trailing `-`. Maybe the `--compiler-prefix` should be changed to `-exec-prefix`?

The change also checks if the tools path is the tools prefix. It is normal to configure packages with a prefix used to build the tools.

The second patch add installing support to aid deployment.